### PR TITLE
Featured lesson - Automatically redirect to the lesson of the week

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -26,6 +26,7 @@
     <script src="bower_components/ionic/release/js/ionic.js"></script>
     <script src="bower_components/ionic/release/js/ionic-angular.js"></script>
     <script src="bower_components/ngCordova/dist/ng-cordova.js"></script>
+    <script src="bower_components/moment/moment.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -39,112 +39,9 @@ angular.module('starter.controllers', [])
       $scope.closeLogin();
     }, 1000);
   };
-
-
-  // at the bottom of your controller
-  //Check what the featured page should be
-    $scope.getFeatured = function ()
-    {
-        //Get the current week
-        var currentWeek = moment().isoWeek();
-        //Get Starting date of this week
-        var startOfWeek = moment().startOf('isoWeek');
-        //Get our pervious month
-        //Number of GOGI Tools
-        var numTools = 12;
-
-
-        //If it is a normal year
-        //organize the weeks with modulo of gogi tools
-        if(currentWeek % numTools == 1)
-        {
-            //Boss of my brain
-            $location.path("app/tool/" + 1);
-        }
-        else if(currentWeek % numTools == 2)
-        {
-            //Belly Breathing
-            $location.path("app/tool/" + 2);
-        }
-        else if(currentWeek % numTools == 3)
-        {
-            //Five Second Lightswitch
-            $location.path("app/tool/" + 3);
-        }
-        else if(currentWeek % numTools == 4)
-        {
-            //Postive thoughts
-            $location.path("app/tool/" + 4);
-        }
-        else if(currentWeek % numTools == 5)
-        {
-            //We need to check if the week is a 5th week of the month
-            //We check if the start of this weeks month is january, April, July or October
-            if(startofWeek.month()  == 0 || startofWeek.month() == 3
-            startofWeek.month()  == 6 || startofWeek.month() == 9)
-            {
-                //If it is, then review
-                $location.path("app/summary/" + 1);
-            }
-            else
-            {
-                //Else, Positive Words
-                $location.path("app/tool/" + 5);
-            }
-        }
-        else if(currentWeek % numTools == 6)
-        {
-            //Positive Actions
-            $location.path("app/tool/" + 6);
-        }
-        else if(currentWeek % numTools == 7)
-        {
-            //Claim Responsibility
-            $location.path("app/tool/" + 7);
-        }
-        else if(currentWeek % numTools == 8)
-        {
-            //Let Go
-            $location.path("app/tool/" + 8);
-        }
-        else if(currentWeek % numTools == 9)
-        {
-            //For--Give
-            $location.path("app/tool/" + 9);
-        }
-        else if(currentWeek % numTools == 10)
-        {
-            //What IF
-            $location.path("app/tool/" + 10);
-        }
-        else if(currentWeek % numTools == 11)
-        {
-            //Reality Check
-            $location.path("app/tool/" + 11);
-        }
-        //Else it is the 12th week zero
-        else
-        {
-            //We need to check if the week is a 5th week of a month
-            //We check if the start of this weeks month is March, June, September or December
-            if(startofWeek.month()  == 2 || startofWeek.month() == 5
-            startofWeek.month()  == 8 || startofWeek.month() == 11)
-            {
-                //If it is, then review
-                $location.path("app/summary/" + 2);
-            }
-            else
-            {
-                //Else, Ultimate Freedom
-                $location.path("app/tool/" + 12);
-            }
-        }
-        }
-
-    };
 })
 
-.controller('PlaylistsCtrl', function($scope) {
+.controller('PlaylistsCtrl', function($scope, $location) {
   $scope.playlists = [
     { title: 'Reggae', id: 1 },
     { title: 'Chill', id: 2 },
@@ -153,6 +50,116 @@ angular.module('starter.controllers', [])
     { title: 'Rap', id: 5 },
     { title: 'Cowbell', id: 6 }
   ];
+
+    //Check what the featured page should be
+    $scope.getFeatured = function ()
+    {
+      //$location.path("app/summary/" + 1);
+      //$location.path("app/tool/" + 5);
+        //Get the current week
+        var currentWeek = moment().isoWeek();
+        //Get Starting date of this week
+        var startOfWeek = moment().startOf('isoWeek');
+        //Get our pervious month
+        //The Gogi Tool we are currently testing
+        var currentTool = 1;
+
+        //The current gogi tool of the month
+        var monthTool = 1;
+
+        //Loop through and simulate the tools for the year
+        for(int i = 1; i < moment().isoWeek() + 1; ++i)
+        {
+            //Get the week
+            var week = moment().isoWeek(i);
+
+            //check if it is our current week
+            if(week == currentWeek)
+            {
+                //Check if it is a review week
+                if(montTool == 5)
+                {
+                        //figure out if we should go to review one or two
+                        //We check if the start of this weeks month is january, April, July or October
+                      if(startofWeek.month()  == 0 || startofWeek.month() == 3 ||
+                      startofWeek.month()  == 6 || startofWeek.month() == 9)
+                      {
+                          //then it is review one
+                          $location.path("app/summary/" + 1);
+                      }
+                      //else this weeks month is March, June, September or December
+                      else
+                      {
+                          //it is review 2
+                          $location.path("app/summary/" + 1); 
+                      }
+                }
+                else
+                {
+                    //go to our tool page
+                    $location.path("app/tool/" + currentTool);
+                }
+                //And break
+                break;
+            }
+
+            //Check if the monthly tool is 4
+            if(monthTool == 4)
+            {
+                //Check next week and see if it is a review week
+                //if next week's starting date's month, is the same as this week's startin day month
+                if(moment().isoWeek(i + 1).startOf('isoWeek').month() == week.startOf('isoWeek').month())
+                {
+                    //this is a 5th review month
+                    //increase month tool but not current tool
+                    ++monthTool;
+                }
+                //It is a new month with a new set of tools
+                else
+                {
+                    if(currentTool >= 12)
+                    {
+                        currentTool = 0;
+                    }
+                    else
+                    {
+                        ++currentTool;
+                    }
+                    monthTool = 0;
+                }
+            }
+            //Also need to check if it is a review week
+            else if(monthTool == 5)
+            {
+                //reset month tool, and now increase current tool
+                if(currentTool >= 12)
+                {
+                    currentTool = 0;
+                }
+                else
+                {
+                    ++currentTool;
+                }
+                monthTool = 0;
+            }
+            //If it is not greater than 3 or 4 then just continue like usual
+            else
+            {
+                if(currentTool >= 12)
+                {
+                    currentTool = 0;
+                }
+                else
+                {
+                    ++currentTool;
+                }
+                ++monthTool;
+            }
+        }
+    };
+
+    $scope.getFeatured();
+
 })
 
 .controller('PlaylistCtrl', function($scope, $stateParams) {

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -54,8 +54,6 @@ angular.module('starter.controllers', [])
     //Check what the featured page should be
     $scope.getFeatured = function ()
     {
-      //$location.path("app/summary/" + 1);
-      //$location.path("app/tool/" + 5);
         //Get the current week
         var currentWeek = moment().isoWeek();
         //Get Starting date of this week
@@ -74,10 +72,12 @@ angular.module('starter.controllers', [])
             var week = moment().isoWeek(i);
 
             //check if it is our current week
-            if(week == currentWeek)
+            if(i == currentWeek)
             {
+                //Alert where we are for testing
+                alert(currentTool + ", " + monthTool + ", " + i);
                 //Check if it is a review week
-                if(montTool == 5)
+                if(monthTool == 5)
                 {
                         //figure out if we should go to review one or two
                         //We check if the start of this weeks month is january, April, July or October
@@ -119,13 +119,13 @@ angular.module('starter.controllers', [])
                 {
                     if(currentTool >= 12)
                     {
-                        currentTool = 0;
+                        currentTool = 1;
                     }
                     else
                     {
                         ++currentTool;
                     }
-                    monthTool = 0;
+                    monthTool = 1;
                 }
             }
             //Also need to check if it is a review week
@@ -134,20 +134,20 @@ angular.module('starter.controllers', [])
                 //reset month tool, and now increase current tool
                 if(currentTool >= 12)
                 {
-                    currentTool = 0;
+                    currentTool = 1;
                 }
                 else
                 {
                     ++currentTool;
                 }
-                monthTool = 0;
+                monthTool = 1;
             }
             //If it is not greater than 3 or 4 then just continue like usual
             else
             {
                 if(currentTool >= 12)
                 {
-                    currentTool = 0;
+                    currentTool = 1;
                 }
                 else
                 {
@@ -159,7 +159,6 @@ angular.module('starter.controllers', [])
     };
 
     $scope.getFeatured();
-
 })
 
 .controller('PlaylistCtrl', function($scope, $stateParams) {

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -1,14 +1,14 @@
 angular.module('starter.controllers', [])
 
 .controller('AppCtrl', function($scope, $ionicModal, $timeout) {
-  
+
   // With the new view caching in Ionic, Controllers are only called
   // when they are recreated or on app start, instead of every page change.
   // To listen for when this page is active (for example, to refresh data),
   // listen for the $ionicView.enter event:
   //$scope.$on('$ionicView.enter', function(e) {
   //});
-  
+
   // Form data for the login modal
   $scope.loginData = {};
 
@@ -39,6 +39,104 @@ angular.module('starter.controllers', [])
       $scope.closeLogin();
     }, 1000);
   };
+
+
+  // at the bottom of your controller
+  //Check what the featured page should be
+    $scope.getFeatured = function ()
+    {
+        //Get the number of iso weeks for the year, 52 is leap year, 53 is normal year
+        var weeksInYear = moment().isoWeeksInYear();
+        //Get the current week
+        var currentWeek = moment().isoWeek();
+        //Get Starting date of this week
+        var startOfWeek = moment().startOf('isoWeek');
+        //Get our pervious month
+        //Number of GOGI Tools
+        var numTools = 12;
+
+
+        //If it is a normal year
+        //organize the weeks with modulo of gogi tools
+        if(weeksInYear > 52)
+        {
+            if(currentWeek % numTools == 1)
+            {
+                //Boss of my brain
+            }
+            else if(currentWeek % numTools == 2)
+            {
+                //Belly Breathing
+            }
+            else if(currentWeek % numTools == 3)
+            {
+                //Five Second Lightswitch
+            }
+            else if(currentWeek % numTools == 4)
+            {
+                //Postive thoughts
+            }
+            else if(currentWeek % numTools == 5)
+            {
+                //We need to check if the week is a 5th week of the month
+                //We check if the start of this weeks month is january, July, April or October
+                if(startofWeek.month()  == 0 || startofWeek.month() == 6
+                startofWeek.month()  == 3 || startofWeek.month() == 9)
+                {
+                    //If it is, then review
+                }
+                else
+                {
+                    //Else, Positive Words
+                }
+            }
+            else if(currentWeek % numTools == 6)
+            {
+                //Positive Actions
+            }
+            else if(currentWeek % numTools == 7)
+            {
+                //Claim Responsibility
+            }
+            else if(currentWeek % numTools == 8)
+            {
+                //Let Go
+            }
+            else if(currentWeek % numTools == 9)
+            {
+                //For--Give
+            }
+            else if(currentWeek % numTools == 10)
+            {
+                //What IF
+            }
+            else if(currentWeek % numTools == 11)
+            {
+                //Reality Check
+            }
+            //Else it is the 12th week zero
+            else
+            {
+                //We need to check if the week is a 5th week of a month
+                //We check if the start of this weeks month is March, September, June, or December
+                if(startofWeek.month()  == 2 || startofWeek.month() == 5
+                startofWeek.month()  == 8 || startofWeek.month() == 11)
+                {
+                    //If it is, then review
+                }
+                else
+                {
+                    //Else, Ultimate Freedom
+                }
+            }
+        }
+        //If it is a leap year
+        else
+        {
+
+        }
+
+    };
 })
 
 .controller('PlaylistsCtrl', function($scope) {

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -68,7 +68,7 @@ angular.module('starter.controllers', [])
         var monthTool = 1;
 
         //Loop through and simulate the tools for the year
-        for(int i = 1; i < moment().isoWeek() + 1; ++i)
+        for(var i = 1; i < moment().isoWeek() + 1; ++i)
         {
             //Get the week
             var week = moment().isoWeek(i);
@@ -91,7 +91,7 @@ angular.module('starter.controllers', [])
                       else
                       {
                           //it is review 2
-                          $location.path("app/summary/" + 1); 
+                          $location.path("app/summary/" + 1);
                       }
                 }
                 else

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -88,6 +88,7 @@ angular.module('starter.controllers', [])
                 startofWeek.month()  == 3 || startofWeek.month() == 9)
                 {
                     //If it is, then review
+                    $location.path("app/summary/" + 1);
                 }
                 else
                 {
@@ -134,6 +135,7 @@ angular.module('starter.controllers', [])
                 startofWeek.month()  == 8 || startofWeek.month() == 11)
                 {
                     //If it is, then review
+                    $location.path("app/summary/" + 2);
                 }
                 else
                 {

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -45,8 +45,6 @@ angular.module('starter.controllers', [])
   //Check what the featured page should be
     $scope.getFeatured = function ()
     {
-        //Get the number of iso weeks for the year, 52 is leap year, 53 is normal year
-        var weeksInYear = moment().isoWeeksInYear();
         //Get the current week
         var currentWeek = moment().isoWeek();
         //Get Starting date of this week
@@ -58,96 +56,89 @@ angular.module('starter.controllers', [])
 
         //If it is a normal year
         //organize the weeks with modulo of gogi tools
-        if(weeksInYear > 52)
+        if(currentWeek % numTools == 1)
         {
-            if(currentWeek % numTools == 1)
+            //Boss of my brain
+            $location.path("app/tool/" + 1);
+        }
+        else if(currentWeek % numTools == 2)
+        {
+            //Belly Breathing
+            $location.path("app/tool/" + 2);
+        }
+        else if(currentWeek % numTools == 3)
+        {
+            //Five Second Lightswitch
+            $location.path("app/tool/" + 3);
+        }
+        else if(currentWeek % numTools == 4)
+        {
+            //Postive thoughts
+            $location.path("app/tool/" + 4);
+        }
+        else if(currentWeek % numTools == 5)
+        {
+            //We need to check if the week is a 5th week of the month
+            //We check if the start of this weeks month is january, April, July or October
+            if(startofWeek.month()  == 0 || startofWeek.month() == 3
+            startofWeek.month()  == 6 || startofWeek.month() == 9)
             {
-                //Boss of my brain
-                $location.path("app/tool/" + 1);
+                //If it is, then review
+                $location.path("app/summary/" + 1);
             }
-            else if(currentWeek % numTools == 2)
-            {
-                //Belly Breathing
-                $location.path("app/tool/" + 2);
-            }
-            else if(currentWeek % numTools == 3)
-            {
-                //Five Second Lightswitch
-                $location.path("app/tool/" + 3);
-            }
-            else if(currentWeek % numTools == 4)
-            {
-                //Postive thoughts
-                $location.path("app/tool/" + 4);
-            }
-            else if(currentWeek % numTools == 5)
-            {
-                //We need to check if the week is a 5th week of the month
-                //We check if the start of this weeks month is january, July, April or October
-                if(startofWeek.month()  == 0 || startofWeek.month() == 6
-                startofWeek.month()  == 3 || startofWeek.month() == 9)
-                {
-                    //If it is, then review
-                    $location.path("app/summary/" + 1);
-                }
-                else
-                {
-                    //Else, Positive Words
-                    $location.path("app/tool/" + 5);
-                }
-            }
-            else if(currentWeek % numTools == 6)
-            {
-                //Positive Actions
-                $location.path("app/tool/" + 6);
-            }
-            else if(currentWeek % numTools == 7)
-            {
-                //Claim Responsibility
-                $location.path("app/tool/" + 7);
-            }
-            else if(currentWeek % numTools == 8)
-            {
-                //Let Go
-                $location.path("app/tool/" + 8);
-            }
-            else if(currentWeek % numTools == 9)
-            {
-                //For--Give
-                $location.path("app/tool/" + 9);
-            }
-            else if(currentWeek % numTools == 10)
-            {
-                //What IF
-                $location.path("app/tool/" + 10);
-            }
-            else if(currentWeek % numTools == 11)
-            {
-                //Reality Check
-                $location.path("app/tool/" + 11);
-            }
-            //Else it is the 12th week zero
             else
             {
-                //We need to check if the week is a 5th week of a month
-                //We check if the start of this weeks month is March, September, June, or December
-                if(startofWeek.month()  == 2 || startofWeek.month() == 5
-                startofWeek.month()  == 8 || startofWeek.month() == 11)
-                {
-                    //If it is, then review
-                    $location.path("app/summary/" + 2);
-                }
-                else
-                {
-                    //Else, Ultimate Freedom
-                    $location.path("app/tool/" + 12);
-                }
+                //Else, Positive Words
+                $location.path("app/tool/" + 5);
             }
         }
-        //If it is a leap year
+        else if(currentWeek % numTools == 6)
+        {
+            //Positive Actions
+            $location.path("app/tool/" + 6);
+        }
+        else if(currentWeek % numTools == 7)
+        {
+            //Claim Responsibility
+            $location.path("app/tool/" + 7);
+        }
+        else if(currentWeek % numTools == 8)
+        {
+            //Let Go
+            $location.path("app/tool/" + 8);
+        }
+        else if(currentWeek % numTools == 9)
+        {
+            //For--Give
+            $location.path("app/tool/" + 9);
+        }
+        else if(currentWeek % numTools == 10)
+        {
+            //What IF
+            $location.path("app/tool/" + 10);
+        }
+        else if(currentWeek % numTools == 11)
+        {
+            //Reality Check
+            $location.path("app/tool/" + 11);
+        }
+        //Else it is the 12th week zero
         else
         {
-
+            //We need to check if the week is a 5th week of a month
+            //We check if the start of this weeks month is March, June, September or December
+            if(startofWeek.month()  == 2 || startofWeek.month() == 5
+            startofWeek.month()  == 8 || startofWeek.month() == 11)
+            {
+                //If it is, then review
+                $location.path("app/summary/" + 2);
+            }
+            else
+            {
+                //Else, Ultimate Freedom
+                $location.path("app/tool/" + 12);
+            }
+        }
         }
 
     };

--- a/app/scripts/controllers.js
+++ b/app/scripts/controllers.js
@@ -1,6 +1,6 @@
 angular.module('starter.controllers', [])
 
-.controller('AppCtrl', function($scope, $ionicModal, $timeout) {
+.controller('AppCtrl', function($scope, $ionicModal, $timeout, $location) {
 
   // With the new view caching in Ionic, Controllers are only called
   // when they are recreated or on app start, instead of every page change.
@@ -63,18 +63,22 @@ angular.module('starter.controllers', [])
             if(currentWeek % numTools == 1)
             {
                 //Boss of my brain
+                $location.path("app/tool/" + 1);
             }
             else if(currentWeek % numTools == 2)
             {
                 //Belly Breathing
+                $location.path("app/tool/" + 2);
             }
             else if(currentWeek % numTools == 3)
             {
                 //Five Second Lightswitch
+                $location.path("app/tool/" + 3);
             }
             else if(currentWeek % numTools == 4)
             {
                 //Postive thoughts
+                $location.path("app/tool/" + 4);
             }
             else if(currentWeek % numTools == 5)
             {
@@ -88,31 +92,38 @@ angular.module('starter.controllers', [])
                 else
                 {
                     //Else, Positive Words
+                    $location.path("app/tool/" + 5);
                 }
             }
             else if(currentWeek % numTools == 6)
             {
                 //Positive Actions
+                $location.path("app/tool/" + 6);
             }
             else if(currentWeek % numTools == 7)
             {
                 //Claim Responsibility
+                $location.path("app/tool/" + 7);
             }
             else if(currentWeek % numTools == 8)
             {
                 //Let Go
+                $location.path("app/tool/" + 8);
             }
             else if(currentWeek % numTools == 9)
             {
                 //For--Give
+                $location.path("app/tool/" + 9);
             }
             else if(currentWeek % numTools == 10)
             {
                 //What IF
+                $location.path("app/tool/" + 10);
             }
             else if(currentWeek % numTools == 11)
             {
                 //Reality Check
+                $location.path("app/tool/" + 11);
             }
             //Else it is the 12th week zero
             else
@@ -127,6 +138,7 @@ angular.module('starter.controllers', [])
                 else
                 {
                     //Else, Ultimate Freedom
+                    $location.path("app/tool/" + 12);
                 }
             }
         }

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "dependencies": {
     "ionic": "v1.0.0-rc.3",
-    "ngCordova": "v0.1.14-alpha"
+    "ngCordova": "v0.1.14-alpha",
+    "moment": "~2.10.3"
   },
   "devDependencies": {
     "angular-mocks": "~1.3.6",
@@ -13,4 +14,3 @@
     "angular": ">= 1.3.6"
   }
 }
-


### PR DESCRIPTION
Finally finished setting the page to the current week we should be switching to on app open. I chose to write a loop to simulate the tools up to that week in the month. Other methods I tried seemed to be unreliable, and I feel that this method will work the best for us, as it will prove to work every year.

I tested this with alerts and console logging, but my grunt is a little wonky so let me know how it goes.

Also, we may need to add momentJS somewhere in our index

and we may need this call: 

var moment = require('moment');
moment().format();

Let me know if we do, since I took this over as @julianpoy was originally working on this

fixes #2
